### PR TITLE
FIXING THE MAJOR ISSUE

### DIFF
--- a/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/Towny/src/main/java/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -319,7 +319,6 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		case "outlawlist":
 		case "plots":
 		case "delete":
-		case "join":
 		case "merge":
 		case "plotgrouplist":
 		case "allylist":
@@ -328,6 +327,12 @@ public class TownCommand extends BaseCommand implements CommandExecutor {
 		case "ranklist":
 			if (args.length == 2)
 				return getTownyStartingWith(args[1], "t");
+			break;
+		case "join":
+			if (args.length == 2) {
+				List<String> randTowns = getTownyStartingWith(args[1], "t");
+				Collections.shuffle(randTowns);
+				return randTowns;}
 			break;
 		case "deposit":
 			if (args.length == 3)


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
To remove the advantage of unicode order in town recruiting by randomizing the tab autocomplete in the /t join command. It has been a major issue on the server for around 6 months now with towns like !America and "Europe" often having a natural advantage over other towns in terms of recruiting. It should theoretically work although the Minecraft client may hard code alphabetical sorting.
____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->
All I did was make a special case for the /t join command to randomize the autocomplete 

____
#### Relevant Towny Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
